### PR TITLE
Test to reproduced the sub-tree recompile behavior

### DIFF
--- a/test/process.jsx
+++ b/test/process.jsx
@@ -76,6 +76,36 @@ describe('process', () => {
     expect(describeSpy).to.have.been.calledOnce
   })
 
+  it('does not recompile children unless changed', () => {
+    const describeSpy = spy()
+    const Child = {
+      describe ({ props }) {
+        describeSpy()
+        return <literal text='test' value={props.data} />
+      }
+    }
+    const Root = {
+      observe () {},
+      describe ({data}) {
+        return (
+          <sequence>
+            <literal text='test' />
+            <Child data={data} />
+          </sequence>
+        )
+      }
+    }
+
+    const register = () => 6
+    const process = createProcessor(register)
+    const parse = compile(<Root />, process)
+
+    parse('')
+    parse('t')
+    parse('te')
+    expect(describeSpy).to.have.been.calledOnce
+  })
+
   it('passes result of register to visit as data', () => {
     const Root = {
       observe () {


### PR DESCRIPTION
While the bound element is not re-described, it looks like children of the element are. From reading the Lacona codebase, it looks like the standard practice is to bind to leaf nodes. I discovered the behavior while following the React pattern of binding near the top of the component tree and passing state via props. 

If this usage is to be supported, a proposal would be to cache the entire subtree description, rather than just the element description. I could re-architect my usage to bind only to leaf nodes, so a fix is not strictly required. However, given the failure mode is functional but slow, it might be good to add warning if non-leaf bound elements are detected. 

I'm happy to assist with either option.
