### PR TITLE
Update deps, verify that elliptical@rc11 fixes extra compilation

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "homepage": "https://github.com/laconalabs/elliptical-observe",
   "devDependencies": {
-    "babel-cli": "^6.7.5",
+    "babel-cli": "^6.7.7",
     "babel-plugin-transform-react-jsx": "^6.7.5",
     "babel-plugin-transform-runtime": "^6.7.5",
     "babel-preset-es2015": "^6.6.0",
@@ -52,8 +52,8 @@
   },
   "dependencies": {
     "babel-runtime": "^6.6.1",
-    "elliptical": "^1.0.0-rc9",
-    "lodash": "^4.8.2",
+    "elliptical": "^1.0.0-rc11",
+    "lodash": "^4.11.1",
     "smart-split": "^3.0.0",
     "zen-observable": "^0.2.1"
   },

--- a/test/process.jsx
+++ b/test/process.jsx
@@ -87,6 +87,31 @@ describe('process', () => {
     const Root = {
       observe () {},
       describe ({data}) {
+        return <Child data={data} />
+      }
+    }
+
+    const register = () => 6
+    const process = createProcessor(register)
+    const parse = compile(<Root />, process)
+
+    parse('')
+    parse('t')
+    parse('te')
+    expect(describeSpy).to.have.been.calledOnce
+  })
+
+  it('does not recompile children unless changed (nested)', () => {
+    const describeSpy = spy()
+    const Child = {
+      describe ({ props }) {
+        describeSpy()
+        return <literal text='test' value={props.data} />
+      }
+    }
+    const Root = {
+      observe () {},
+      describe ({data}) {
         return (
           <sequence>
             <literal text='test' />


### PR DESCRIPTION
So the bug reported in #1 was actually caused by an oversight in laconalabs/elliptical.

We just straight-up weren't caching `describe` calls that came about because of `traverse` calls within a `visit` function. See the commit here: https://github.com/laconalabs/elliptical/commit/447606aadc4cf14145e6b5c9aced3cc51d21da7b

Go ahead and test this out, @jmalins. And thanks so much for the find and the great reproduction/info!